### PR TITLE
Change to "DB2" as that seems the most-common IBM way

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,11 @@ An application to collect error codes of several widely used applications in one
 
 While still in development stage this application supports
 
-- IBM **Db2 for z/OS** *10.0.0*
+- IBM **DB2 for z/OS** *10.0.0*
+- IBM **DB2 for z/OS** *11.0.0*
+- IBM **DB2 for z/OS** *12.0.0*
 - IBM **MQ** *8.0.0*
+- W3C **HTTP** *1.1*
 
 Feel free to add support for more product from other vendors to we all don't need to use all our time searching for error codes.
 

--- a/src/main/kotlin/org/olafneumann/errorcodes/codes/IbmCodeDescriptionProviders.kt
+++ b/src/main/kotlin/org/olafneumann/errorcodes/codes/IbmCodeDescriptionProviders.kt
@@ -65,7 +65,7 @@ abstract class SqlCodeDescriptionProvider(
 
 class Db2Zos10CodeDescriptionProvider : SqlCodeDescriptionProvider(
     "ibm-db2-for-zos-10",
-    "Db2 for z/OS",
+    "DB2 for z/OS",
     "10.0.0",
     Url("https://www.ibm.com/support/knowledgecenter/SSEPEK_10.0.0/codes/src/tpc/db2z_n.html?view=embed"),
     Regex("<li class=\"ulchildlink\"[^>]*>.*?<a\\s[^>]*href=\"([^\"]+)\"[^>]*>(-?[0-9]+)</a>((?:[^<]|<(?!/li))*?)</li>"),
@@ -74,7 +74,7 @@ class Db2Zos10CodeDescriptionProvider : SqlCodeDescriptionProvider(
 
 class Db2Zos11CodeDescriptionProvider : SqlCodeDescriptionProvider(
     "ibm-db2-for-zos-11",
-    "Db2 for z/OS",
+    "DB2 for z/OS",
     "11.0.0",
     Url("https://www.ibm.com/support/knowledgecenter/SSEPEK_11.0.0/codes/src/tpc/db2z_n.html?view=embed"),
     Regex("<li class=\"ulchildlink\"[^>]*>.*?<a\\s[^>]*href=\"([^\"]+)\"[^>]*>(-?[0-9]+)</a>((?:[^<]|<(?!/li))*?)</li>"),
@@ -83,7 +83,7 @@ class Db2Zos11CodeDescriptionProvider : SqlCodeDescriptionProvider(
 
 class Db2Zos12CodeDescriptionProvider : SqlCodeDescriptionProvider(
     "ibm-db2-for-zos-12",
-    "Db2 for z/OS",
+    "DB2 for z/OS",
     "12.0.0",
     Url("https://www.ibm.com/support/knowledgecenter/SSEPEK_12.0.0/codes/src/tpc/db2z_n.html?view=embed"),
     Regex("<li class=\"ulchildlink\"[^>]*>.*?<a\\s[^>]*href=\"([^\"]+)\"[^>]*>(-?[0-9]+)</a>((?:[^<]|<(?!/li))*?)</li>"),


### PR DESCRIPTION
* Change to "DB2" as that seems the most-common IBM way
* Update the list of supported applications in README